### PR TITLE
Dynamic Port assignment for DatagramEnqueuer

### DIFF
--- a/src/main/java/org/lwes/listener/DatagramEnqueuer.java
+++ b/src/main/java/org/lwes/listener/DatagramEnqueuer.java
@@ -152,6 +152,10 @@ public class DatagramEnqueuer extends ThreadedEnqueuer {
             else {
                 socket = new DatagramSocket(port, address);
             }
+            
+            if(port == 0){
+            	port = socket.getLocalPort();
+            }
         }
         int bufSize = MAX_DATAGRAM_SIZE * 50;
         String bufSizeStr = System.getProperty("MulticastReceiveBufferSize");


### PR DESCRIPTION
Modified the DatagramEnqueuer so that if a port of 0 is passed in and assigned dynamically, the port field is set to the chosen port.
