### PR TITLE
Updated the clear method of MapEvent

### DIFF
--- a/src/main/java/org/lwes/MapEvent.java
+++ b/src/main/java/org/lwes/MapEvent.java
@@ -310,7 +310,7 @@ public class MapEvent extends DefaultEvent {
     public void clear(String attributeName) {
         final BaseType bt = attributes.remove(attributeName);
         if (bt != null) {
-            bytesStoreSize -= bt.bytesStoreSize(encoding);
+            bytesStoreSize -= (attributeName.length() + 1) + bt.bytesStoreSize(encoding);
         }
     }
 


### PR DESCRIPTION
The byteStoreSize wasn't being updated correctly.  attributeName.length() + 1 also needs to be
subtracted.
