### PR TITLE
Found bug in last pull request

### DIFF
--- a/src/test/java/org/lwes/FieldTypeTest.java
+++ b/src/test/java/org/lwes/FieldTypeTest.java
@@ -10,6 +10,11 @@ import org.junit.Test;
 
 import junit.framework.Assert;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class FieldTypeTest {
 
     private static transient Log log = LogFactory.getLog(FieldTypeTest.class);
@@ -24,5 +29,43 @@ public class FieldTypeTest {
     public void testIsArray() {
         Assert.assertTrue(FieldType.UINT64_ARRAY.isArray());
         Assert.assertFalse(FieldType.UINT64.isArray());
+    }
+    
+    @Test
+    public void testTypeMappings() {
+      for (FieldType type : FieldType.values()) {
+        assertEquals(type.name()+" is "+(type.isArray()?"":"not ")+" an array",
+            type.name().endsWith("_ARRAY"), type.isArray());
+        if (type.isArray()) {
+          final FieldType componentType = type.getComponentType();
+          assertNotNull("Array "+type.name()+" had no component",
+              componentType);
+          assertEquals("Component type and array type should be bound: "+type,
+              (componentType.getArrayType()==type), ! type.isNullableArray());
+          if (componentType == FieldType.IPADDR) {
+            // IPADDR has no nullable array type, so don't check for one.
+          } else {
+            assertEquals("Iff this is a nullable array type, its component should know this too: "+type,
+                (componentType.getNullableArrayType()==type), type.isNullableArray());
+          }
+        } else {
+          final FieldType arrayType = type.getArrayType();
+          assertEquals("An array type and component type should be consistent: "+type,
+              type, arrayType.getComponentType());
+          assertFalse("Non-nullable array types shouldn't start with N",
+              arrayType.name().startsWith("N"));
+          if (type == FieldType.IPADDR) {
+            // IPADDR has no nullable array type, so don't check for one.
+          } else {
+            final FieldType nullableArrayType = type.getNullableArrayType();
+            assertEquals("A nullable array type and component type should be consistent: "+type,
+                type, nullableArrayType.getComponentType());
+            assertTrue("Nullable array types should start with N: "+type,
+                nullableArrayType.name().startsWith("N"));
+            assertFalse("Nullable and non-nullable array types should not be the same: "+type,
+                arrayType == nullableArrayType);
+          }
+        }
+      }
     }
 }


### PR DESCRIPTION
Fixing bug in last rev of FieldType.getArrayType(), adding more tests to cover that, and replacing more switch blocks with algorithmically-determined cached state.

When looking at the component/array type mappings, it was taking the first match in getArrayType() when it should have restricted to the first (and hopefully only) non-nullable array type for that component type.
