### PR TITLE
Don't fail when unicode characters are present in comments

### DIFF
--- a/src/main/java/org/lwes/db/EventTemplateDB.java
+++ b/src/main/java/org/lwes/db/EventTemplateDB.java
@@ -147,11 +147,11 @@ public class EventTemplateDB {
         ESFParser parser;
         try {
             if (getESFInputStream() != null) {
-                parser = new ESFParser(getESFInputStream());
+                parser = new ESFParser(getESFInputStream(), "UTF-8");
             }
             else if (getESFFile() != null) {
                 parser = new ESFParser(
-                        new java.io.FileInputStream(getESFFile()));
+                        new java.io.FileInputStream(getESFFile()), "UTF-8");
             }
             else {
                 return false;

--- a/src/main/javacc/ESFParser.jj
+++ b/src/main/javacc/ESFParser.jj
@@ -14,6 +14,7 @@ options {
   DEBUG_PARSER=false;
   DEBUG_LOOKAHEAD=false;
   DEBUG_TOKEN_MANAGER=false;
+  JAVA_UNICODE_ESCAPE = true ; 
   STATIC=false;
 }
 


### PR DESCRIPTION
We found out that parser would fail if unicode characters were present in the ESF.
This small patch tells javacc to use java (unicode) character streams and successfully parses ESFs with unicode
