### PR TITLE
Snappy compression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+          <version>1.1.0-M3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/lwes/emitter/UnicastEventEmitter.java
+++ b/src/main/java/org/lwes/emitter/UnicastEventEmitter.java
@@ -63,7 +63,7 @@ public class UnicastEventEmitter implements EventEmitter {
 	private int port = 9191;
 
 	/* a lock variable to synchronize events */
-	private Object lock = new Object();
+	protected Object lock = new Object();
 
 	/**
 	 * Default constructor.

--- a/src/main/java/org/lwes/emitter/UnicastSnappyEventEmitter.java
+++ b/src/main/java/org/lwes/emitter/UnicastSnappyEventEmitter.java
@@ -1,0 +1,29 @@
+package org.lwes.emitter;
+
+import java.io.IOException;
+
+import org.lwes.Event;
+import org.lwes.EventSystemException;
+import org.xerial.snappy.Snappy;
+
+/**
+ * @author dgoya
+ *
+ */
+public class UnicastSnappyEventEmitter extends UnicastEventEmitter {
+
+	/**
+	 * Emits the compressed event to the network.
+	 *
+	 * @param event the event to emit
+	 * @exception IOException throws an IOException is there is a network error.
+     * @throws EventSystemException if unable to serialize the event
+	 */
+	public void emit(Event event) throws IOException, EventSystemException {
+		byte[] msgBytes = event.serialize();
+		synchronized(lock) {
+			emit(Snappy.compress(msgBytes));
+		}
+	}
+
+}

--- a/src/main/java/org/lwes/listener/DatagramDequeuer.java
+++ b/src/main/java/org/lwes/listener/DatagramDequeuer.java
@@ -95,7 +95,7 @@ public class DatagramDequeuer extends ThreadedDequeuer {
         /* now try to deserialize the packet */
         try {
             /* don't validate the event for now to save time */
-            Event event = factory.createEvent(packet.getData(), false);
+            Event event = factory.createEvent(getData(packet), false);
             event.setInt64(Event.RECEIPT_TIME, timestamp);
             event.setIPAddress(Event.SENDER_IP, address);
             event.setUInt16(Event.SENDER_PORT, port);
@@ -109,5 +109,9 @@ public class DatagramDequeuer extends ThreadedDequeuer {
                 log.warn("Unable to deserialize event in handleElement()", e);
             }
         }
+    }
+    
+    protected byte[] getData (DatagramPacket packet) throws IOException {
+    	return packet.getData();
     }
 }

--- a/src/main/java/org/lwes/listener/DatagramEventListener.java
+++ b/src/main/java/org/lwes/listener/DatagramEventListener.java
@@ -37,15 +37,21 @@ import java.util.Collection;
  */
 public class DatagramEventListener extends ThreadedEventListener {
     /* the enqueuer to use to acquire multicast packets */
-    private DatagramEnqueuer enqueuer = new DatagramEnqueuer();
+    private DatagramEnqueuer enqueuer;
 
     /* the dequeuer to use to handle packets */
-    private DatagramDequeuer dequeuer = new DatagramDequeuer();
+    private DatagramDequeuer dequeuer;
 
     /**
      * Default constructor.
      */
     public DatagramEventListener() {
+    	this(new DatagramEnqueuer(), new DatagramDequeuer());
+    }
+    
+    protected DatagramEventListener(DatagramEnqueuer enqueuer, DatagramDequeuer dequeuer){
+    	this.enqueuer = enqueuer;
+    	this.dequeuer = dequeuer;
     }
 
     /**

--- a/src/main/java/org/lwes/listener/SnappyDatagramDequeuer.java
+++ b/src/main/java/org/lwes/listener/SnappyDatagramDequeuer.java
@@ -1,0 +1,18 @@
+package org.lwes.listener;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+
+import org.xerial.snappy.Snappy;
+
+/**
+ * @author dgoya
+ *
+ */
+public class SnappyDatagramDequeuer extends DatagramDequeuer {
+
+	@Override
+	protected byte[] getData(DatagramPacket packet) throws IOException {
+		return Snappy.uncompress(packet.getData());
+	}
+}

--- a/src/main/java/org/lwes/listener/SnappyDatagramEventListener.java
+++ b/src/main/java/org/lwes/listener/SnappyDatagramEventListener.java
@@ -1,0 +1,12 @@
+package org.lwes.listener;
+
+/**
+ * @author dgoya
+ *
+ */
+public class SnappyDatagramEventListener extends DatagramEventListener {
+
+    public SnappyDatagramEventListener(){
+    	 super(new DatagramEnqueuer(), new SnappyDatagramDequeuer());
+    }
+}


### PR DESCRIPTION
I added a snappy compression layer which should be pretty transparent to everything below it.  Data is compressed after Event serialization and before it is packed into a DatagramPacket.  Data is decompressed before Event serialization, after it is pulled out of a DatagramPacket.