### PR TITLE
The code change is to make it easy to extend DatagramEventListener and DatagramEnqueuer.  It doesn't add new functionalities.

### DIFF
--- a/src/main/java/org/lwes/listener/DatagramEnqueuer.java
+++ b/src/main/java/org/lwes/listener/DatagramEnqueuer.java
@@ -12,14 +12,14 @@
 
 package org.lwes.listener;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.MulticastSocket;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * This class listens to packets sent via UDP, and enqueues them for processing.
@@ -35,7 +35,7 @@ public class DatagramEnqueuer extends ThreadedEnqueuer {
 
     /* max datagram size in bytes */
     private static final int MAX_DATAGRAM_SIZE = 65535;
-    private String DEFAULT_ADDRESS = "224.0.0.69";
+    private final String DEFAULT_ADDRESS = "224.0.0.69";
 
     /* the default network settings */
     private InetAddress address = null;
@@ -44,13 +44,13 @@ public class DatagramEnqueuer extends ThreadedEnqueuer {
     private int ttl = 31;
 
     /* the network socket */
-    private DatagramSocket socket = null;
+    protected DatagramSocket socket = null;
 
     /* a running buffer */
-    private byte[] buffer = null;
+    protected byte[] buffer = null;
 
     /* thread control */
-    private boolean running = false;
+    protected boolean running = false;
 
     public DatagramEnqueuer() {
         super();
@@ -152,7 +152,7 @@ public class DatagramEnqueuer extends ThreadedEnqueuer {
             else {
                 socket = new DatagramSocket(port, address);
             }
-            
+
             if(port == 0){
             	port = socket.getLocalPort();
             }

--- a/src/main/java/org/lwes/listener/DatagramEventListener.java
+++ b/src/main/java/org/lwes/listener/DatagramEventListener.java
@@ -12,16 +12,14 @@
 
 package org.lwes.listener;
 
-import org.lwes.EventSystemException;
-
 import java.net.InetAddress;
 import java.util.Collection;
 
 /**
- * This is an event listener that handles UDP packets.  Automatically
- * detects multicast addresses and joins those groups.
+ * This is an event listener that handles UDP packets. Automatically detects multicast addresses and joins those groups.
  * <p/>
  * Sample code that prints multicast events to stdout:
+ *
  * <pre>
  * EventHandler myHandler = new EventPrintingHandler();
  * InetAddress address = InetAddress.getByName("224.0.0.69");
@@ -35,19 +33,22 @@ import java.util.Collection;
  *
  * @author Michael P. Lum
  */
-public class DatagramEventListener extends ThreadedEventListener {
-    /* the enqueuer to use to acquire multicast packets */
-    private DatagramEnqueuer enqueuer = new DatagramEnqueuer();
-
-    /* the dequeuer to use to handle packets */
-    private DatagramDequeuer dequeuer = new DatagramDequeuer();
+public class DatagramEventListener extends ThreadedEventListener<DatagramEnqueuer, DatagramDequeuer> {
 
     /**
      * Default constructor.
      */
     public DatagramEventListener() {
+        /* the enqueuer to use to acquire multicast packets */
+        enqueuer = new DatagramEnqueuer();
+        /* the dequeuer to use to handle packets */
+        dequeuer = new DatagramDequeuer();
     }
 
+    public DatagramEventListener(DatagramEnqueuer enqueuer, DatagramDequeuer dequeuer) {
+        this.enqueuer = enqueuer;
+        this.dequeuer = dequeuer;
+    }
     /**
      * Gets the address to use for this listener
      *
@@ -118,8 +119,8 @@ public class DatagramEventListener extends ThreadedEventListener {
     }
 
     /**
-     * Get the TTL to use for this listener.  Only applies to
-     * multicast listeners.  Typically this does not need to be changed.
+     * Get the TTL to use for this listener. Only applies to multicast listeners. Typically this does not need to be
+     * changed.
      *
      * @return the interface
      */
@@ -131,8 +132,8 @@ public class DatagramEventListener extends ThreadedEventListener {
     }
 
     /**
-     * Sets the TTL to use for this listener.  Only applies to multicast listeners.
-     * Typically this does not need to be changed.
+     * Sets the TTL to use for this listener. Only applies to multicast listeners. Typically this does not need to be
+     * changed.
      *
      * @param ttl the TTL value
      */
@@ -166,8 +167,8 @@ public class DatagramEventListener extends ThreadedEventListener {
     }
 
     /**
-     * Adds an event handler to this listener.  This has a callback that will be invoked
-     * for every event coming through the system.
+     * Adds an event handler to this listener. This has a callback that will be invoked for every event coming through
+     * the system.
      *
      * @param handler the EventHandler to add
      */
@@ -179,8 +180,8 @@ public class DatagramEventListener extends ThreadedEventListener {
     }
 
     /**
-     * Removes an event handler from the system.  This causes the event handler to no longer
-     * receive events coming through the system.
+     * Removes an event handler from the system. This causes the event handler to no longer receive events coming
+     * through the system.
      *
      * @param handler the EventHandler to remove
      */
@@ -196,17 +197,4 @@ public class DatagramEventListener extends ThreadedEventListener {
         }
         return null;
     }
-
-    /**
-     * Initializes the listener.
-     *
-     * @throws EventSystemException thrown if there is a problem initializing the listener
-     */
-    @Override
-    public void initialize() throws EventSystemException {
-        this.setEnqueuer(enqueuer);
-        this.setDequeuer(dequeuer);
-        super.initialize();
-	}
-
 }

--- a/src/main/java/org/lwes/listener/ThreadedEventListener.java
+++ b/src/main/java/org/lwes/listener/ThreadedEventListener.java
@@ -14,13 +14,13 @@ package org.lwes.listener;
 
 import org.lwes.EventSystemException;
 
-public abstract class ThreadedEventListener implements EventListener {
+public abstract class ThreadedEventListener<E extends ThreadedEnqueuer, D extends ThreadedDequeuer> implements EventListener {
     /* the processor for handling events */
     protected ThreadedProcessor processor = new ThreadedProcessor();
 
     /* the event enqueuer and dequeuer */
-    private ThreadedEnqueuer enqueuer = null;
-    private ThreadedDequeuer dequeuer = null;
+    protected E enqueuer = null;
+    protected D dequeuer = null;
 
     private int queueSize = -1;
 
@@ -43,7 +43,7 @@ public abstract class ThreadedEventListener implements EventListener {
      *
      * @return the enqueuer
      */
-    public ThreadedEnqueuer getEnqueuer() {
+    public E getEnqueuer() {
         return enqueuer;
     }
 
@@ -52,7 +52,7 @@ public abstract class ThreadedEventListener implements EventListener {
      *
      * @param enqueuer the enqueuer to set
      */
-    public void setEnqueuer(ThreadedEnqueuer enqueuer) {
+    public void setEnqueuer(E enqueuer) {
         this.enqueuer = enqueuer;
     }
 
@@ -61,7 +61,7 @@ public abstract class ThreadedEventListener implements EventListener {
      *
      * @return the dequeuer
      */
-    public ThreadedDequeuer getDequeuer() {
+    public D getDequeuer() {
         return dequeuer;
     }
 
@@ -70,7 +70,7 @@ public abstract class ThreadedEventListener implements EventListener {
      *
      * @param dequeuer the dequeuer to set
      */
-    public void setDequeuer(ThreadedDequeuer dequeuer) {
+    public void setDequeuer(D dequeuer) {
         this.dequeuer = dequeuer;
     }
 

--- a/src/test/java/org/lwes/listener/DatagramEventListenerTest.java
+++ b/src/test/java/org/lwes/listener/DatagramEventListenerTest.java
@@ -6,10 +6,10 @@ package org.lwes.listener;
 
 import java.util.Collection;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.lwes.Event;
-
-import junit.framework.Assert;
 
 public class DatagramEventListenerTest {
 
@@ -17,13 +17,11 @@ public class DatagramEventListenerTest {
     public void testNulls() {
         DatagramEventListener listener = new DatagramEventListener();
         listener.initialize();
-        listener.setEnqueuer(null);
-        listener.setDequeuer(null);
 
         Assert.assertNotNull(listener.getAddress());
         Assert.assertNull(listener.getInterface());
-        Assert.assertNull(listener.getEnqueuer());
-        Assert.assertNull(listener.getDequeuer());
+        Assert.assertNotNull(listener.getEnqueuer());
+        Assert.assertNotNull(listener.getDequeuer());
 
     }
 


### PR DESCRIPTION
1. made ThreadedEventListener generic, and change enqueuer and dequeuer to be protected
2. DatagramEventListener reuses enqueuer and dequeuer from parent class
3. changed some fields in DatagramEnqueuer to be protected so it can be extended easily.
