### PR TITLE
Support for registration of new EmitterGroup

### DIFF
--- a/src/main/java/org/lwes/emitter/EmitterGroupBuilder.java
+++ b/src/main/java/org/lwes/emitter/EmitterGroupBuilder.java
@@ -11,33 +11,50 @@
  *======================================================================*/
 package org.lwes.emitter;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Properties;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.io.IOException;
 
 import org.apache.log4j.Logger;
 import org.lwes.EventFactory;
 import org.lwes.emitter.EmitterGroupFilter.FilterType;
 
 /**
- * @author Joel Meyer
+ * <p>Build an array of emitter groups from a java Properties object.</p>
+ * <p>A registration mechanism is available to allow plugins to
+ * define new "types" of EmitterGroups.</p>
  *
+ * @author Joel Meyer
  */
 public class EmitterGroupBuilder {
-  private static final Logger LOG = Logger.getLogger(EmitterGroupBuilder.class);
+  private static HashMap<String, EmitterGroupFactory> emitterGroupFactoryRegistry;
+  static {
+    registerEmitterGroupFactory("udp", new UDPEmitterGroupFactory());
+  }
 
-  private static String STRATEGY_ALL = "all";
-  private static Pattern STRATEGY_M_OF_N = Pattern.compile("([\\d]*)ofN", Pattern.CASE_INSENSITIVE);
-  private static Pattern STRATEGY_NESTED = Pattern.compile("(([\\d|]*)ofN|all)_(([\\d]*)ofN|all)", Pattern.CASE_INSENSITIVE);
-  private static Pattern nestedTuplePattern = Pattern.compile("^((\\([^\\(]+?\\))(,)*)+$", Pattern.CASE_INSENSITIVE);
-  private static Pattern tuplePattern = Pattern.compile("\\([^\\(]+?\\)", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * <p>Register a new 'type' of emitter.</p>
+   * <p>The default emitter is 'udp'.</p>
+   * <p>A 'gcs' emitter is available as a plugin.</p>
+   *
+   * @param type the name of the type of the emitter,
+   * which must be given as lwes.{{GROUPNAME}}.type in the configuration.
+   * The default type, and the only builtin type, is 'udp'.
+   * @param factory An interface that spits out 
+   * EmitterGroups, give a Properties object and a prefix to look under.
+   */
+  public synchronized static void registerEmitterGroupFactory(String type, EmitterGroupFactory factory) {
+    //
+    // This pattern is, of course, not thread safe, but all registration
+    // should occur on the main java thread.
+    //
+    if (emitterGroupFactoryRegistry == null) {
+      emitterGroupFactoryRegistry = new HashMap<String, EmitterGroupFactory>();
+    }
+
+    emitterGroupFactoryRegistry.put(type, factory);
+  }
 
   public static EmitterGroup[] createGroups(Properties props,
                                             EventFactory factory)
@@ -58,223 +75,17 @@ public class EmitterGroupBuilder {
     return createGroups(props, null);
   }
 
-  public static EmitterGroupFilter getEmitterGroupFilter(Properties props, String prefix) {
-    String filterType = props.getProperty(prefix + "filter.type");
-    if (filterType == null) return null;
-
-    FilterType type = null;
-
-    if ("inclusion".equalsIgnoreCase(filterType) ||
-        "whitelist".equalsIgnoreCase(filterType) ||
-        "in".equalsIgnoreCase(filterType)) {
-      type = FilterType.Inclusion;
-    } else if ("exclusion".equalsIgnoreCase(filterType) ||
-               "blacklist".equalsIgnoreCase(filterType) ||
-               "out".equalsIgnoreCase(filterType)) {
-      type = FilterType.Exclusion;
-    } else {
-      throw new RuntimeException(
-          String.format(
-              "Invalid filter type: %s. Must be one of ['inclusion', 'whitelist', 'in'] or ['exclusion','blacklist','out']",
-              filterType));
-    }
-
-    String filteredNames = props.getProperty(prefix + "filter.names");
-    if (filteredNames == null || filteredNames.isEmpty()) {
-      return new EmitterGroupFilter(type, Collections.<String>emptySet());
-    } else {
-      Set<String> filtered = new HashSet<String>();
-      String[] items = filteredNames.split(",");
-      for (String item : items) filtered.add(item);
-      return new EmitterGroupFilter(type, filtered);
-    }
-  }
 
   public static EmitterGroup createGroup(Properties props, String groupName,
                                          EventFactory factory)
       throws IOException {
     String prefix = "lwes." + groupName + ".";
-
-    String defaultPortStr = props.getProperty(prefix + "port");
-    int defaultPort = (defaultPortStr != null) ? Integer.parseInt(defaultPortStr) : -1;
-
-    String hostsStr = props.getProperty(prefix + "hosts");
-    String strategy = props.getProperty(prefix + "strategy");
-    boolean emitHeartbeat =
-      Boolean.parseBoolean(props.getProperty(prefix + "emit_heartbeat"));
-
-    String rateStr = props.getProperty(prefix + "sample_rate");
-    double defaultSampleRate = null == rateStr ? 1.0 : Double.parseDouble(rateStr);
-
-    EmitterGroupFilter filter = getEmitterGroupFilter(props, prefix);
-    if (filter != null) {
-      LOG.info(String.format("Emitter group %s : %s", groupName, filter));
-    }
-
-    if (STRATEGY_NESTED.matcher(strategy).matches()) {
-      return buildNestedEmitterGroup(prefix, hostsStr, strategy, defaultPort, filter, defaultSampleRate, emitHeartbeat, factory);
-    }
-
-    DatagramSocketEventEmitter<?>[] emitters =
-      createEmitters(groupName, prefix, hostsStr, defaultPort, emitHeartbeat, factory);
-
-    if (strategy == null || strategy.isEmpty()) {
-      throw new RuntimeException(
-          String.format(
-              "No strategy specified for emitter group %s - not set in %s property",
-              groupName,
-              prefix + "strategy"));
-    }
-
-    Matcher mOfN = STRATEGY_M_OF_N.matcher(strategy);
-
-    if (STRATEGY_ALL.equalsIgnoreCase(strategy)) {
-      return new BroadcastEmitterGroup(emitters, filter, defaultSampleRate, factory);
-    } else if (mOfN.matches()) {
-      return new MOfNEmitterGroup(emitters, Integer.parseInt(mOfN.group(1)), filter, defaultSampleRate, factory);
-    } else {
-      throw new RuntimeException(
-          String.format(
-              "Invalid strategy '%s' given for emitter group %s in property %s.",
-              strategy,
-              groupName,
-              prefix + "strategy"));
-    }
-  }
-
-  public static EmitterGroup createGroup(Properties props, String groupName) throws IOException {
-    return createGroup(props, groupName, null);
-  }
-
-  private static EmitterGroup buildNestedEmitterGroup(String prefix, String hostsStr, String strategyStr, int port, EmitterGroupFilter filter, double sampleRate, boolean emitHeartbeat, EventFactory factory) throws IOException {
-  String[] ratioConfig = strategyStr.split("_");
-  if (null == ratioConfig || ratioConfig.length != 2) {
-    throw new IllegalArgumentException("Invalid nested strategy config " + strategyStr);
-  }
-  if (!nestedTuplePattern.matcher(hostsStr).find()) {
-    throw new IllegalArgumentException("Invalid nested hosts config " + hostsStr);
+    String type = props.getProperty(prefix + "type", "udp");
+    EmitterGroupFactory f = emitterGroupFactoryRegistry.get(type);
+    if (f == null)
+      throw new RuntimeException("no emitter-group factory of type " + type + " known");
+    return f.create(props, groupName, prefix, factory);
   }
 
 
-  int hostEmitCount = getEmitCount(ratioConfig[1]);
-
-  Matcher groupMatcher = tuplePattern.matcher(hostsStr);
-  List<EmitterGroup> emitterGroups = new ArrayList<EmitterGroup>();
-  while (groupMatcher.find()) {
-    String group = groupMatcher.group();
-    String groupHosts = group.replaceAll("\\(|\\)", "");
-    DatagramSocketEventEmitter<?>[] emitters =
-      createEmitters(group, prefix, groupHosts, port, emitHeartbeat, factory);
-    MOfNEmitterGroup meg = new MOfNEmitterGroup(emitters, hostEmitCount == -1 ? emitters.length : hostEmitCount, filter, factory);
-    emitterGroups.add(meg);
-  }
-
-  int groupEmitCount = getEmitCount(ratioConfig[0]);
-  EmitterGroup[] emitterGroupsArray = emitterGroups.toArray(new EmitterGroup[emitterGroups.size()]);
-  return new NestedEmitterGroup(emitterGroupsArray, groupEmitCount == -1 ? emitterGroupsArray.length : groupEmitCount, filter, sampleRate, factory);
-  }
-
-  /**
-   * Get emit count for a MOfN type configuration string, -1 implies all of N.
-   * @param config
-   * @return
-   */
-  private static int getEmitCount(String config) {
-  if (STRATEGY_ALL.equalsIgnoreCase(config)) {
-    return -1;
-  } else {
-    Matcher mOfN = STRATEGY_M_OF_N.matcher(config);
-    if (!mOfN.matches()) {
-    throw new IllegalArgumentException("Unable to parse nested strategy config " + config);
-    }
-    return Integer.parseInt(mOfN.group(1));
-    }
-  }
-
-  private static DatagramSocketEventEmitter<?>[] createEmitters(String groupName, String prefix, String hostsStr, int defaultPort, boolean emitHeartbeat, EventFactory factory) throws IOException {
-    String[] hosts = hostsStr.split(",");
-    DatagramSocketEventEmitter<?>[] emitters = new DatagramSocketEventEmitter<?>[hosts.length];
-
-    for (int i = 0; i < hosts.length; i++) {
-      String host = hosts[i];
-      String ifaceStr = null;
-      Integer port = null;
-      String ttlStr = null;
-
-      // accepted formats:
-      // HOST, IFACE:HOST, HOST:PORT, IFACE:HOST:PORT, HOST:PORT:TTL, IFACE:HOST:PORT:TTL
-      if (host.indexOf(":") > 0) {
-        String[] parts = host.split(":");
-        if (parts.length == 2) {
-          try {
-            port = Integer.parseInt(parts[1]);
-            host = parts[0];
-          } catch (NumberFormatException nfe) {
-            ifaceStr = parts[0];
-            host = parts[1];
-          }
-        } else if (parts.length == 3) {
-          try {
-            port = Integer.parseInt(parts[1]);
-            host = parts[0];
-            ttlStr = parts[2];
-          } catch (NumberFormatException nfe) {
-            ifaceStr = parts[0];
-            host = parts[1];
-            port = Integer.parseInt(parts[2]);
-          }
-        } else if (parts.length == 4) {
-          ifaceStr = parts[0];
-          host = parts[1];
-          port = Integer.parseInt(parts[2]);
-          ttlStr = parts[3];
-        } else {
-          throw new RuntimeException(
-            String.format("Unable to parse LWES emitter group %s host config %s",
-                          groupName, host));
-        }
-      }
-
-      InetAddress address = InetAddress.getByName(host);
-      InetAddress iface = (ifaceStr == null ? null : InetAddress.getByName(ifaceStr));
-      int ttl = (ttlStr == null ? -1 : Integer.parseInt(ttlStr));
-
-      if (port == null) {
-        if (defaultPort < 0) {
-          throw new RuntimeException(
-              String.format(
-                  "Unable to get port information for LWES emitter group %s - not specified " +
-                  "in %s or as part of the host definition (e.g. host1:port1,host2:port2).",
-                  groupName, prefix + "port"));
-        } else {
-          port = defaultPort;
-        }
-      }
-
-      if (address.isMulticastAddress()) {
-        MulticastEventEmitter mee =
-          (factory == null ? new MulticastEventEmitter() :
-                             new MulticastEventEmitter(factory));
-
-        mee.setInterface(iface);
-
-        if (ttl > 0) {
-          mee.setTimeToLive(ttl);
-        }
-
-        emitters[i] = mee;
-      } else {
-        emitters[i] =
-          (factory == null ? new UnicastEventEmitter() :
-                             new UnicastEventEmitter(factory));
-      }
-
-      emitters[i].setAddress(address);
-      emitters[i].setPort(port);
-      emitters[i].setEmitHeartbeat(emitHeartbeat);
-      emitters[i].initialize();
-    }
-
-    return emitters;
-  }
 }

--- a/src/main/java/org/lwes/emitter/EmitterGroupFactory.java
+++ b/src/main/java/org/lwes/emitter/EmitterGroupFactory.java
@@ -1,0 +1,26 @@
+/*======================================================================*
+ * Copyright OpenX Limited 2010. All Rights Reserved.                   *
+ *                                                                      *
+ * Licensed under the New BSD License (the "License"); you may not use  *
+ * this file except in compliance with the License.  Unless required    *
+ * by applicable law or agreed to in writing, software distributed      *
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT        *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.     *
+ * See the License for the specific language governing permissions and  *
+ * limitations under the License. See accompanying LICENSE file.        *
+ *======================================================================*/
+package org.lwes.emitter;
+
+import java.util.HashMap;
+import java.util.Properties;
+import java.io.IOException;
+
+import org.apache.log4j.Logger;
+import org.lwes.EventFactory;
+import org.lwes.emitter.EmitterGroupFilter.FilterType;
+
+
+@FunctionalInterface
+public interface EmitterGroupFactory {
+  public EmitterGroup create(Properties props, String groupName, String prefix, EventFactory factory) throws IOException;
+}

--- a/src/main/java/org/lwes/emitter/EmitterGroupFilter.java
+++ b/src/main/java/org/lwes/emitter/EmitterGroupFilter.java
@@ -12,6 +12,9 @@
 package org.lwes.emitter;
 
 import java.util.Set;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Collections;
 
 public class EmitterGroupFilter {
   public static enum FilterType {
@@ -39,4 +42,39 @@ public class EmitterGroupFilter {
     for (String e : filtered) sb.append(e).append(" ");
     return sb.toString();
   }
+
+
+  // Helper method
+  public static EmitterGroupFilter fromProperties(Properties props, String prefix) {
+    String filterType = props.getProperty(prefix + "filter.type");
+    if (filterType == null) return null;
+
+    FilterType type = null;
+
+    if ("inclusion".equalsIgnoreCase(filterType) ||
+        "whitelist".equalsIgnoreCase(filterType) ||
+        "in".equalsIgnoreCase(filterType)) {
+      type = FilterType.Inclusion;
+    } else if ("exclusion".equalsIgnoreCase(filterType) ||
+               "blacklist".equalsIgnoreCase(filterType) ||
+               "out".equalsIgnoreCase(filterType)) {
+      type = FilterType.Exclusion;
+    } else {
+      throw new RuntimeException(
+          String.format(
+              "Invalid filter type: %s. Must be one of ['inclusion', 'whitelist', 'in'] or ['exclusion','blacklist','out']",
+              filterType));
+    }
+
+    String filteredNames = props.getProperty(prefix + "filter.names");
+    if (filteredNames == null || filteredNames.isEmpty()) {
+      return new EmitterGroupFilter(type, Collections.<String>emptySet());
+    } else {
+      Set<String> filtered = new HashSet<String>();
+      String[] items = filteredNames.split(",");
+      for (String item : items) filtered.add(item);
+      return new EmitterGroupFilter(type, filtered);
+    }
+  }
+
 }

--- a/src/main/java/org/lwes/emitter/UDPEmitterGroupFactory.java
+++ b/src/main/java/org/lwes/emitter/UDPEmitterGroupFactory.java
@@ -1,0 +1,210 @@
+package org.lwes.emitter;
+
+import org.lwes.Event;
+import org.lwes.EventFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+
+public class UDPEmitterGroupFactory implements EmitterGroupFactory {
+  private static final Logger LOG = Logger.getLogger(EmitterGroupBuilder.class);
+
+  private static String STRATEGY_ALL = "all";
+  private static Pattern STRATEGY_M_OF_N = Pattern.compile("([\\d]*)ofN", Pattern.CASE_INSENSITIVE);
+  private static Pattern STRATEGY_NESTED = Pattern.compile("(([\\d|]*)ofN|all)_(([\\d]*)ofN|all)", Pattern.CASE_INSENSITIVE);
+  private static Pattern nestedTuplePattern = Pattern.compile("^((\\([^\\(]+?\\))(,)*)+$", Pattern.CASE_INSENSITIVE);
+  private static Pattern tuplePattern = Pattern.compile("\\([^\\(]+?\\)", Pattern.CASE_INSENSITIVE);
+
+  @Override
+  public EmitterGroup create(Properties props, String groupName, String prefix, EventFactory factory) throws IOException {
+    String defaultPortStr = props.getProperty(prefix + "port");
+    int defaultPort = (defaultPortStr != null) ? Integer.parseInt(defaultPortStr) : -1;
+
+    String hostsStr = props.getProperty(prefix + "hosts");
+    String strategy = props.getProperty(prefix + "strategy");
+    boolean emitHeartbeat =
+      Boolean.parseBoolean(props.getProperty(prefix + "emit_heartbeat"));
+
+    String rateStr = props.getProperty(prefix + "sample_rate");
+    double defaultSampleRate = null == rateStr ? 1.0 : Double.parseDouble(rateStr);
+
+    EmitterGroupFilter filter = EmitterGroupFilter.fromProperties(props, prefix);
+    if (filter != null) {
+      LOG.info(String.format("Emitter group %s : %s", prefix, filter));
+    }
+
+    if (STRATEGY_NESTED.matcher(strategy).matches()) {
+      return buildNestedEmitterGroup(prefix, hostsStr, strategy, defaultPort, filter, defaultSampleRate, emitHeartbeat, factory);
+    }
+
+    DatagramSocketEventEmitter<?>[] emitters =
+      createEmitters(groupName, prefix, hostsStr, defaultPort, emitHeartbeat, factory);
+
+    if (strategy == null || strategy.isEmpty()) {
+      throw new RuntimeException(
+          String.format(
+              "No strategy specified for emitter group %s - not set in %s property",
+              groupName,
+              prefix + "strategy"));
+    }
+
+    Matcher mOfN = STRATEGY_M_OF_N.matcher(strategy);
+
+    if (STRATEGY_ALL.equalsIgnoreCase(strategy)) {
+      return new BroadcastEmitterGroup(emitters, filter, defaultSampleRate, factory);
+    } else if (mOfN.matches()) {
+      return new MOfNEmitterGroup(emitters, Integer.parseInt(mOfN.group(1)), filter, defaultSampleRate, factory);
+    } else {
+      throw new RuntimeException(
+          String.format(
+              "Invalid strategy '%s' given for emitter group %s in property %s.",
+              strategy,
+              prefix,
+              prefix + "strategy"));
+    }
+  }
+
+  private static EmitterGroup buildNestedEmitterGroup(String prefix, String hostsStr, String strategyStr, int port, EmitterGroupFilter filter, double sampleRate, boolean emitHeartbeat, EventFactory factory) throws IOException {
+  String[] ratioConfig = strategyStr.split("_");
+  if (null == ratioConfig || ratioConfig.length != 2) {
+    throw new IllegalArgumentException("Invalid nested strategy config " + strategyStr);
+  }
+  if (!nestedTuplePattern.matcher(hostsStr).find()) {
+    throw new IllegalArgumentException("Invalid nested hosts config " + hostsStr);
+  }
+
+
+  int hostEmitCount = getEmitCount(ratioConfig[1]);
+
+  Matcher groupMatcher = tuplePattern.matcher(hostsStr);
+  List<EmitterGroup> emitterGroups = new ArrayList<EmitterGroup>();
+  while (groupMatcher.find()) {
+    String group = groupMatcher.group();
+    String groupHosts = group.replaceAll("\\(|\\)", "");
+    DatagramSocketEventEmitter<?>[] emitters =
+      createEmitters(group, prefix, groupHosts, port, emitHeartbeat, factory);
+    MOfNEmitterGroup meg = new MOfNEmitterGroup(emitters, hostEmitCount == -1 ? emitters.length : hostEmitCount, filter, factory);
+    emitterGroups.add(meg);
+  }
+
+  int groupEmitCount = getEmitCount(ratioConfig[0]);
+  EmitterGroup[] emitterGroupsArray = emitterGroups.toArray(new EmitterGroup[emitterGroups.size()]);
+  return new NestedEmitterGroup(emitterGroupsArray, groupEmitCount == -1 ? emitterGroupsArray.length : groupEmitCount, filter, sampleRate, factory);
+  }
+
+  /**
+   * Get emit count for a MOfN type configuration string, -1 implies all of N.
+   * @param config
+   * @return
+   */
+  private static int getEmitCount(String config) {
+  if (STRATEGY_ALL.equalsIgnoreCase(config)) {
+    return -1;
+  } else {
+    Matcher mOfN = STRATEGY_M_OF_N.matcher(config);
+    if (!mOfN.matches()) {
+    throw new IllegalArgumentException("Unable to parse nested strategy config " + config);
+    }
+    return Integer.parseInt(mOfN.group(1));
+    }
+  }
+
+  private static DatagramSocketEventEmitter<?>[] createEmitters(String groupName, String prefix, String hostsStr, int defaultPort, boolean emitHeartbeat, EventFactory factory) throws IOException {
+    String[] hosts = hostsStr.split(",");
+    DatagramSocketEventEmitter<?>[] emitters = new DatagramSocketEventEmitter<?>[hosts.length];
+
+    for (int i = 0; i < hosts.length; i++) {
+      String host = hosts[i];
+      String ifaceStr = null;
+      Integer port = null;
+      String ttlStr = null;
+
+      // accepted formats:
+      // HOST, IFACE:HOST, HOST:PORT, IFACE:HOST:PORT, HOST:PORT:TTL, IFACE:HOST:PORT:TTL
+      if (host.indexOf(":") > 0) {
+        String[] parts = host.split(":");
+        if (parts.length == 2) {
+          try {
+            port = Integer.parseInt(parts[1]);
+            host = parts[0];
+          } catch (NumberFormatException nfe) {
+            ifaceStr = parts[0];
+            host = parts[1];
+          }
+        } else if (parts.length == 3) {
+          try {
+            port = Integer.parseInt(parts[1]);
+            host = parts[0];
+            ttlStr = parts[2];
+          } catch (NumberFormatException nfe) {
+            ifaceStr = parts[0];
+            host = parts[1];
+            port = Integer.parseInt(parts[2]);
+          }
+        } else if (parts.length == 4) {
+          ifaceStr = parts[0];
+          host = parts[1];
+          port = Integer.parseInt(parts[2]);
+          ttlStr = parts[3];
+        } else {
+          throw new RuntimeException(
+            String.format("Unable to parse LWES emitter group %s host config %s",
+                          groupName, host));
+        }
+      }
+
+      InetAddress address = InetAddress.getByName(host);
+      InetAddress iface = (ifaceStr == null ? null : InetAddress.getByName(ifaceStr));
+      int ttl = (ttlStr == null ? -1 : Integer.parseInt(ttlStr));
+
+      if (port == null) {
+        if (defaultPort < 0) {
+          throw new RuntimeException(
+              String.format(
+                  "Unable to get port information for LWES emitter group %s - not specified " +
+                  "in %s or as part of the host definition (e.g. host1:port1,host2:port2).",
+                  groupName, prefix + "port"));
+        } else {
+          port = defaultPort;
+        }
+      }
+
+      if (address.isMulticastAddress()) {
+        MulticastEventEmitter mee =
+          (factory == null ? new MulticastEventEmitter() :
+                             new MulticastEventEmitter(factory));
+
+        mee.setInterface(iface);
+
+        if (ttl > 0) {
+          mee.setTimeToLive(ttl);
+        }
+
+        emitters[i] = mee;
+      } else {
+        emitters[i] =
+          (factory == null ? new UnicastEventEmitter() :
+                             new UnicastEventEmitter(factory));
+      }
+
+      emitters[i].setAddress(address);
+      emitters[i].setPort(port);
+      emitters[i].setEmitHeartbeat(emitHeartbeat);
+      emitters[i].initialize();
+    }
+
+    return emitters;
+  }
+
+}


### PR DESCRIPTION
You might ask: is the EmitterGroup the right place to provide this abstraction?  The answer is "no" but we would have to break compatibility in various ways.

Ignoring compatibility, I'd probably reduce the EventEmitter interface to just a single method "emit" and EmitterGroup would merely be an implementation of EventEmitter that uses an array of sub-EventEmitters (raw UDP emitters) and a strategy (eg MofN subemitters must complete).

However, the existing users have little choice but to use EmitterGroupBuilder, since that's the level that parses configuration files.