### PR TITLE
various cleanups needed for javadoc 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>net.java.dev.javacc</groupId>
       <artifactId>javacc</artifactId>
-      <version>5.0</version>
+      <version>7.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -308,7 +308,10 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
+            <version>3.0.1</version>
+            <configuration>
+              <doclint>none</doclint>
+            </configuration>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/src/main/java/org/lwes/ArrayEvent.java
+++ b/src/main/java/org/lwes/ArrayEvent.java
@@ -80,9 +80,9 @@ public final class ArrayEvent extends DefaultEvent {
     
     /**
      * Creates a new event from the given byte array, copying it only if the copy flag is true.
-     * @param bytes
-     * @param len - Portion of the byte array to use. Must be no greater than total length.
-     * @param copy - If true, the bytes prefix is copied to a newly allocated array.
+     * @param bytes An initial value for the contents of the event.
+     * @param len Portion of the byte array to use. Must be no greater than total length.
+     * @param copy Whether to copy the byte array source; useful if the bytes may change in the future.  Of course, it's fast not to copy if they aren't going to change.
      */
     public ArrayEvent(final byte[] bytes, final int len, final boolean copy) {
         // We assume that bytes has the right encoding, no need to set it.
@@ -104,7 +104,7 @@ public final class ArrayEvent extends DefaultEvent {
     
     /**
      * Creates a new event, making a copy of the given byte array into a newly allocated buffer
-     * @param bytes
+     * @param bytes an array of bytes to copy into the new event.
      */
     public ArrayEvent(final byte[] bytes) {
         this(bytes, bytes.length, true);
@@ -570,15 +570,17 @@ public final class ArrayEvent extends DefaultEvent {
     }
 
     /**
-     * These two ArrayEvent objects swap all of their fields.
-     * <p/>
-     * Why would one want to do this? If one must set "this" to the value of
+     * <p>These two ArrayEvent objects swap all of their fields.</p>
+     * <p>Why would one want to do this? If one must set "this" to the value of
      * "event", but it's acceptable to modify "event" in the process, then
-     * swap() accomplishes the copy faster than copyFrom(event) can.
-     * <p/>
+     * swap() accomplishes the copy faster than copyFrom(event) can.</p>
+     * <p>
      * Typical events seem to take about 6ms for copyFrom() but only 100ns for
      * swap().  However, if you're not doing enough copies that the performance
      * difference matters, you should probably use copyFrom().
+     * </p>
+     *
+     * @param event an event whose contents will be swapped with 'this'.
      */
     public void swap(ArrayEvent event) {
         if (this == event) {
@@ -601,10 +603,16 @@ public final class ArrayEvent extends DefaultEvent {
     }
 
     /**
-     * Return a new ArrayEvent with an unusually small buffer. The maximum length
-     * for this trimmed ArrayEvent is its initial length. This should only be used
+     * <p>Return a new ArrayEvent with an unusually small buffer. The maximum length
+     * for this trimmed ArrayEvent is its initial length plus the number
+     * of bytes passed in. This should only be used
      * for testing operations, when we might want to store a large number of
      * events in memory at once.
+     * </p>
+     *
+     * @param excess the number of bytes the returned event can grow.
+     *
+     * @return the new ArrayEvent.
      */
     public ArrayEvent trim(int excess) {
         final int overrun = length + excess - MAX_MESSAGE_SIZE;
@@ -639,6 +647,8 @@ public final class ArrayEvent extends DefaultEvent {
      * This method shows detailed information about the internal state of the
      * event, and was designed as a "Detail Formatter" for tracing execution
      * under Eclipse.  It may be useful for other IDEs or other uses.
+     *
+     * @return a multiline string giving information about the event.
      */
     public String toStringDetailed() {
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/lwes/BaseType.java
+++ b/src/main/java/org/lwes/BaseType.java
@@ -18,13 +18,14 @@ import org.lwes.serializer.StringParser;
 import org.lwes.util.EncodedString;
 
 /**
- * This class provides a base type for the base types in the event system. acts
+ * <p>This class provides a base type for the base types in the event system. acts
  * partially as an interface and partially to provide encapsulation of the
  * TypeIDs used in serialization.
- * <p/>
+ * </p><p>
  * It also provides a sizeof() type method called getByteSize() used to
  * determine how many bytes must be used to serialize an object of the given
  * type.
+ * </p>
  *
  * @author Anthony Molinaro
  */
@@ -158,6 +159,8 @@ public class BaseType {
 
     /**
      * use {@link #setType(FieldType)}
+     *
+     * @param typeName a string that is a valid FieldType name.
      */
     @Deprecated
     public void setTypeName(String typeName) {
@@ -166,6 +169,8 @@ public class BaseType {
 
     /**
      * use {@link #getType()}
+     *
+     * @return the name of the FieldType
      */
     @Deprecated
     public String getTypeName() {
@@ -174,6 +179,8 @@ public class BaseType {
 
     /**
      * use {@link #setType(FieldType)}
+     *
+     * @param typeToken byte-code for this FieldType.
      */
     @Deprecated
     public void setTypeToken(byte typeToken) {

--- a/src/main/java/org/lwes/MapEvent.java
+++ b/src/main/java/org/lwes/MapEvent.java
@@ -60,6 +60,9 @@ public class MapEvent extends DefaultEvent {
 
     /**
      * Create an event called <tt>eventName</tt> with no validation
+     *
+     * @param eventName String this is the event's name.
+     * @throws EventSystemException event name was somehow invalid
      */
     public MapEvent(String eventName) throws EventSystemException {
         this(eventName, false, null);
@@ -99,6 +102,7 @@ public class MapEvent extends DefaultEvent {
      *
      * @param eventName the name of the event
      * @param validate  true if the EventTemplateDB should be checked for types before all mutations
+     * @param eventTemplateDB template-database which can be used for validation.
      * @param encoding  the character encoding used by the event
      * @throws NoSuchEventException         if the Event does not exist in the EventTemplateDB
      * @throws NoSuchAttributeException     if an attribute does not exist in the EventTemplateDB
@@ -119,9 +123,9 @@ public class MapEvent extends DefaultEvent {
      *
      * @param bytes           the raw bytes to convert
      * @param eventTemplateDB the EventTemplateDB to use to validate the event
-     * @throws NoSuchEventException
-     * @throws NoSuchAttributeException
-     * @throws NoSuchAttributeTypeException
+     * @throws NoSuchEventException         if the Event does not exist in the EventTemplateDB
+     * @throws NoSuchAttributeException     if an attribute does not exist in the EventTemplateDB
+     * @throws NoSuchAttributeTypeException if an attribute type does not exist in the EventTemplateDB
      */
     public MapEvent(byte[] bytes, EventTemplateDB eventTemplateDB)
             throws EventSystemException {
@@ -135,9 +139,9 @@ public class MapEvent extends DefaultEvent {
      * @param bytes           the raw bytes to convert
      * @param validate        whether or not to validate the event
      * @param eventTemplateDB the EventTemplateDB to use to validate the event
-     * @throws NoSuchEventException
-     * @throws NoSuchAttributeException
-     * @throws NoSuchAttributeTypeException
+     * @throws NoSuchEventException the event is not found in the template-database.
+     * @throws NoSuchAttributeException unknown attribute encountered in this message (?)
+     * @throws NoSuchAttributeTypeException attribute has wrong type (?)
      */
     public MapEvent(byte[] bytes, boolean validate, EventTemplateDB eventTemplateDB)
             throws EventSystemException {
@@ -492,7 +496,7 @@ public class MapEvent extends DefaultEvent {
      * Deserialize the Event from byte array
      *
      * @param bytes the byte array containing a serialized Event
-     * @throws EventSystemException
+     * @throws EventSystemException a parse error occurred interpreting the bytes.
      */
     @Override
     public void deserialize(byte[] bytes, int offset, int length)
@@ -600,7 +604,10 @@ public class MapEvent extends DefaultEvent {
     }
 
     /**
-     * This returns the number of bytes necessary for serialization, not the number of attributes.
+     * Get the number of bytes in the serialized event.
+     * (This is precomputed, hence this function is fast)
+     * 
+     * @return the number of bytes necessary for serialization, not the number of attributes.
      */
     @Override
     public int getBytesSize() {

--- a/src/main/java/org/lwes/NoSuchAttributeException.java
+++ b/src/main/java/org/lwes/NoSuchAttributeException.java
@@ -19,6 +19,8 @@ package org.lwes;
 public class NoSuchAttributeException extends EventSystemException {
 	/**
 	 * Overrides <tt>EventSystemException</tt> constructor
+         *
+         * @param s human-readable description of error
 	 */
 	public NoSuchAttributeException(String s) {
 		super(s);

--- a/src/main/java/org/lwes/NoSuchAttributeTypeException.java
+++ b/src/main/java/org/lwes/NoSuchAttributeTypeException.java
@@ -20,6 +20,8 @@ package org.lwes;
 public class NoSuchAttributeTypeException extends EventSystemException {
 	/**
 	 * Overrides <tt>EventSystemException</tt> Constructor
+         *
+         * @param s human-readable description of error
 	 */
 	public NoSuchAttributeTypeException(String s) {
 		super(s);

--- a/src/main/java/org/lwes/NoSuchEventException.java
+++ b/src/main/java/org/lwes/NoSuchEventException.java
@@ -20,6 +20,8 @@ package org.lwes;
 public class NoSuchEventException extends EventSystemException {
 	/**
 	 * Overrides <tt>EventSystemException</tt> constructor
+         *
+         * @param s human-readable description of error.
 	 */
 	public NoSuchEventException(String s) {
 		super(s);

--- a/src/main/java/org/lwes/ValidationExceptions.java
+++ b/src/main/java/org/lwes/ValidationExceptions.java
@@ -80,6 +80,10 @@ public class ValidationExceptions extends EventSystemException {
      *   ve = ValidationExceptions.append(ve, new EventSystemException("label 2");
      * }
      * </code></pre>
+     *
+     * @param existing optional event to appeach exceptions to (if null, it will be created)
+     * @param exceptions a list of subexceptions to add to returned collection.
+     * @return either the existing Exceptions collection object, or a newly allocated ValidationExceptions.
      */
     public static ValidationExceptions append(ValidationExceptions existing, EventSystemException... exceptions) {
         final ValidationExceptions result;

--- a/src/main/java/org/lwes/db/EventTemplateDB.java
+++ b/src/main/java/org/lwes/db/EventTemplateDB.java
@@ -280,6 +280,8 @@ public class EventTemplateDB {
      *                        given in the ESF Specification.
      * @param size            The size restriction for this attribute
      * @param required        Is this attribute required
+     * @param defaultValue    The default value for this attribute.
+     * @param comment         Human-readable information about this attribute.
      * @return true if the attribute can be added, false if it can not.
      */
     public synchronized boolean addEventAttribute(String anEventName,
@@ -467,7 +469,7 @@ public class EventTemplateDB {
                 eventName, attributeName, value, min, max));
     }
 
-    /**
+    /*
      * use {@link #addEventAttribute(String, String, FieldType, Integer, boolean, Object)}
      */
     @Deprecated
@@ -536,6 +538,10 @@ public class EventTemplateDB {
      * This checks an attribute against a limit on the number of elements in an
      * array, and does not check the number of serialized bytes required to
      * store the value.
+     * @param eventName      the name of an Event.
+     * @param attributeName  the name of an attribute of <tt>eventName</tt>
+     * @param attributeValue the value of the attribute
+     * @throws EventAttributeSizeException size invalid.
      */
     public void checkForSize(String eventName,
                              String attributeName,
@@ -672,7 +678,7 @@ public class EventTemplateDB {
         return false;
     }
 
-    /**
+    /*
      * use {@link #checkTypeForAttribute(String, String, FieldType)}
      */
     @Deprecated

--- a/src/main/java/org/lwes/emitter/MulticastEventEmitter.java
+++ b/src/main/java/org/lwes/emitter/MulticastEventEmitter.java
@@ -21,17 +21,18 @@ import java.net.InetAddress;
 import java.net.MulticastSocket;
 
 /**
- * MulticastEventEmitter emits events to multicast groups on the network.  This is the most common
- * class used by users of the Light Weight Event System.
- * <p/>
+ * <p>MulticastEventEmitter emits events to multicast groups on the network.  This is the most common
+ * class used by users of the Light Weight Event System.</p>
+ * <p>
  * Example code:
+ * </p>
  * <pre>
  * MulticastEventEmitter emitter = new MulticastEventEmitter();
  * emitter.setESFFilePath("/path/to/esf/file");
  * emitter.setMulticastAddress(InetAddress.getByName("224.0.0.69"));
  * emitter.setMulticastPort(9191);
  * emitter.initialize();
- * <p/>
+
  * Event e = emitter.createEvent("MyEvent", false);
  * e.setString("key","value");
  * emitter.emit(e);
@@ -60,7 +61,8 @@ public class MulticastEventEmitter extends DatagramSocketEventEmitter<MulticastS
   }
 
   /**
-   * Sets the multicast address for this emitter.  Preserved for backwards compatibility.
+   * Sets the multicast address for this emitter.
+   * Preserved for backwards compatibility.
    *
    * @param address the multicast address
    */
@@ -115,6 +117,8 @@ public class MulticastEventEmitter extends DatagramSocketEventEmitter<MulticastS
 
   /**
    * Creates the multicast <code>MulticastSocket</code>.
+   *
+   * @throws IOException if an error occurs.
    */
   @Override
   protected void createSocket() throws IOException {

--- a/src/main/java/org/lwes/emitter/NestedEmitterGroup.java
+++ b/src/main/java/org/lwes/emitter/NestedEmitterGroup.java
@@ -60,7 +60,7 @@ public class NestedEmitterGroup extends EmitterGroup {
   /**
    * Emits the event to the network.
    *
-   * @param event the event to emit
+   * @param e the event to emit
    * @return number of bytes emitted
    */
   @Override

--- a/src/main/java/org/lwes/listener/DatagramEventListener.java
+++ b/src/main/java/org/lwes/listener/DatagramEventListener.java
@@ -16,14 +16,16 @@ import java.net.InetAddress;
 import java.util.Collection;
 
 /**
- * This is an event listener that handles UDP packets. Automatically detects multicast addresses and joins those groups.
- * <p/>
+ * <p>This is an event listener that handles UDP packets. Automatically detects multicast addresses and joins those groups.
+ * </p>
+ * <p>
  * Sample code that prints multicast events to stdout:
+ * </p>
  *
  * <pre>
  * EventHandler myHandler = new EventPrintingHandler();
  * InetAddress address = InetAddress.getByName("224.0.0.69");
- * <p/>
+ *
  * DatagramEventListener listener = new DatagramEventListener();
  * listener.setAddress(address);
  * listener.setPort(9191);

--- a/src/main/java/org/lwes/serializer/Serializer.java
+++ b/src/main/java/org/lwes/serializer/Serializer.java
@@ -155,8 +155,8 @@ public class Serializer {
 
     /**
      * String arrays are serialized as follows:
-     * <array_name_len><array_name_bytes><type>
-     * <array_length><serialized_type_1>...<serialized_type_n>
+     * &lt;array_name_len&gt;&lt;array_name_bytes&gt;&lt;type&gt;
+     * &lt;array_length&gt;&lt;serialized_type_1&gt;...&lt;serialized_type_n&gt;
      *
      * @param value
      * @param bytes

--- a/src/main/java/org/lwes/util/NumberCodec.java
+++ b/src/main/java/org/lwes/util/NumberCodec.java
@@ -18,19 +18,22 @@ import org.apache.commons.logging.LogFactory;
 import java.math.BigInteger;
 
 /**
- * This is a class to efficiently encode built-in primitive types into
+ * <p>This is a class to efficiently encode built-in primitive types into
  * byte arrays and decode them back.  While this can be done with a
  * combination of ByteArrayOutputStreams, DataOutputStreams,
  * ByteArrayInputStreams, DataInputStreams, merely creating those
  * objects is quite costly and it is difficult to make them persistent.
  * As such, this contains code lifted from the guts of the Data*Stream
  * classes.
- * <p/>
+ * </p>
+ * <p>
  * Also, this class defines functions to convert primitive types and
  * byte arrays to and from hexadecimal strings.
- * <p/>
+ * </p>
+ * <p>
  * Hopefully, support for these operations will be added to
  * the standard Java API and this class can be retired.
+ * </p>
  *
  * @author Preston Pfarner
  * @author Michael P. Lum

--- a/src/main/javacc/ESFParser.jj
+++ b/src/main/javacc/ESFParser.jj
@@ -98,7 +98,7 @@ TOKEN :
 
 }
 
-/**
+/*
  * A list of events
  */
 void eventlist() :
@@ -115,7 +115,7 @@ void eventlist() :
    )* <EOF> 
 }
 
-/**
+/*
  * a single event
  */
 void event() :
@@ -125,7 +125,7 @@ void event() :
   eventName() "{" [ attributeList() ] "}"
 }
 
-/**
+/*
  * The name of an event, should be max 256 chars ([a-zA-Z0-9_]*)
  */
 void eventName() :


### PR DESCRIPTION
unfortunately, an upgrade to an unreleased javacc is needed
to actually allow javadoc to build there. see:
  https://github.com/javacc/javacc/pull/82

Although I think upgrading the more recent javacc (a futile experiment) and maven-javadoc-plugin (needed to specify the doclint property) are pretty harmless, i could revert them, since they don't actually make 'mvn javadoc:javadoc' work.